### PR TITLE
Implement reloading of configuration on file change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ExrmReload [![Build Status](https://travis-ci.org/xerions/exrm_reload.svg)](https://travis-ci.org/xerions/exrm_reload)
 
-Build new sys.config from confrom config and apply it at runtume. 
+Build new sys.config from confrom config and apply it at runtume.
 It uses `conform_schema` and `conform_config` command line flags which are set on [exrm](https://github.com/bitwalker/exrm) startup script.
 
 ## Usage
@@ -9,7 +9,7 @@ It uses `conform_schema` and `conform_config` command line flags which are set o
 
     ```elixir
     def deps do
-        [{:exrm_reload, github: "xerions/exrm_reload"}]
+      [{:exrm_reload, github: "xerions/exrm_reload"}]
     end
     ```
 
@@ -17,7 +17,7 @@ It uses `conform_schema` and `conform_config` command line flags which are set o
 
     ```elixir
     def application do
-        [applications: [:exrm_reload]]
+      [applications: [:exrm_reload]]
     end
     ```
 
@@ -38,3 +38,27 @@ It works with the releases are builded via `exrm`. You just call it by rpc from 
 	$ you_application rpc ReleaseManager.Reload run
 
 The test application uses xerions forks of [exrm](https://github.com/xerions/exrm) and [conform](https://github.com/xerions/conform) but it can work with the original exrm version `>= 0.19.7` and conform. Just override it.
+
+## Usage for developing
+
+1. It is possible to use for developing:
+
+    ```elixir
+    config :exrm_reload,
+      watch: false,
+      dev: Mix.env == :dev
+    ```
+
+2. Add this 5-liner to your `config/dev.exs` (it can be used only for `dev` enviroment) to use conform configuration reloaded in development mode.
+
+    ```elixir
+    app = Mix.Project.get!.project[:app]
+    :code.add_path('_build/#{Mix.env}/lib/conform/ebin')
+    {:ok, conf} = Conform.Conf.from_file("config/#{app}.conf")
+    config = Conform.Schema.load!("config/#{app}.schema.exs") |> Conform.Translate.to_config([], conf)
+    for {app, envs} <- config, do: config(app, envs)
+
+    config :exrm_reload,
+      watch: true,
+      dev: true
+    ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,5 @@
 use Mix.Config
 
 config :exrm_reload,
-  watch: false
+  watch: false,
+  dev: false

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :exrm_reload,
+  watch: false

--- a/config/exrm_reload.conf
+++ b/config/exrm_reload.conf
@@ -1,3 +1,3 @@
 # Provide documentation for exrm_reload.watch here.
-exrm_reload.watch = false
+config.watch = false
 

--- a/config/exrm_reload.conf
+++ b/config/exrm_reload.conf
@@ -1,0 +1,3 @@
+# Provide documentation for exrm_reload.watch here.
+exrm_reload.watch = false
+

--- a/config/exrm_reload.schema.exs
+++ b/config/exrm_reload.schema.exs
@@ -1,0 +1,14 @@
+[
+  import: [
+  ],
+  mappings: [
+    "config.watch": [
+      doc: "Watch for configuration changes and apply it directly",
+      to: "exrm_reload.watch",
+      datatype: :atom,
+      default: false
+    ]
+  ],
+  translations: [
+  ]
+]

--- a/lib/exrm_reload.ex
+++ b/lib/exrm_reload.ex
@@ -1,0 +1,44 @@
+defmodule ExrmReload do
+  use Application
+  import Supervisor.Spec, warn: false
+
+  # See http://elixir-lang.org/docs/stable/elixir/Application.html
+  # for more information on OTP Applications
+  def start(_type, _args) do
+    children = []
+    opts = [strategy: :one_for_one, name: ExrmReload.Supervisor]
+    {:ok, sup} = Supervisor.start_link(children, opts)
+    Application.get_env(:exrm_reload, :watch) |> check_watch()
+    {:ok, sup}
+  end
+
+  def config_change(changed, _new, _removed) do
+    changed[:watch] |> check_watch
+  end
+
+  def check_watch(watch?) do
+    if watch? do start_watcher else stop_watcher end
+  end
+
+  defp start_watcher() do
+    {:ok, [[config]]} = :init.get_argument(:conform_config)
+    supervisor = supervisor(:fs, [:exrm_reload_watcher, Path.dirname(config) |> to_char_list], id: :exrm_reload_watcher)
+    Supervisor.start_child(ExrmReload.Supervisor, supervisor)
+    Supervisor.start_child(ExrmReload.Supervisor, worker(ExrmReload.Watcher, []))
+    :ok
+  end
+
+  defp stop_watcher() do
+    stop_child(:exrm_reload_watcher)
+    stop_child(ExrmReload.Watcher)
+  end
+
+  defp stop_child(id) do
+    case Supervisor.terminate_child(ExrmReload.Supervisor, id) do
+      :ok ->
+        :ok = Supervisor.delete_child(ExrmReload.Supervisor, id)
+      {:error, :not_found} ->
+        :not_found
+    end
+  end
+end

--- a/lib/exrm_reload.ex
+++ b/lib/exrm_reload.ex
@@ -21,8 +21,13 @@ defmodule ExrmReload do
   end
 
   defp start_watcher() do
-    {:ok, [[config]]} = :init.get_argument(:conform_config)
-    supervisor = supervisor(:fs, [:exrm_reload_watcher, Path.dirname(config) |> to_char_list], id: :exrm_reload_watcher)
+    path = if Application.get_env(:exrm_reload, :dev) do
+        Path.expand("config")
+      else
+        {:ok, [[config]]} = :init.get_argument(:conform_config)
+        Path.dirname(config) |> to_char_list
+    end
+    supervisor = supervisor(:fs, [:exrm_reload_watcher, path], id: :exrm_reload_watcher)
     Supervisor.start_child(ExrmReload.Supervisor, supervisor)
     Supervisor.start_child(ExrmReload.Supervisor, worker(ExrmReload.Watcher, []))
     :ok

--- a/lib/exrm_reload/reload.ex
+++ b/lib/exrm_reload/reload.ex
@@ -1,7 +1,7 @@
 defmodule ReleaseManager.Reload do
   @moduledoc """
-  Reload plugin for EXRM. 
-  
+  Reload plugin for EXRM.
+
   It works at the runtime system.
   It generates new sys.config by conform config and schema and applies changes via application_controller.
 
@@ -21,24 +21,23 @@ defmodule ReleaseManager.Reload do
     case :init.get_argument(:running_conf) do
       {:ok, [[running_conf]]} -> File.copy! config, running_conf
       _ -> :skip
-    end 
-    generate_sys_config(schema, config, sys_config) 
+    end
+    generate_sys_config(schema, config, sys_config)
     |> check_config!
     |> reload(applications)
   end
-
 
   defp generate_sys_config(schema, config, sys_config) do
     config = config |> List.to_string |> :conf_parse.file
     schema = schema |> List.to_string |> Conform.Schema.load! |> Dict.delete(:import)
     :code.is_loaded(Conform.SysConfig) == false and :code.load_file(Conform.SysConfig)
     case function_exported?(Conform.SysConfig, :read, 1) do
-      true ->  
-        {:ok, [conf]} = Conform.SysConfig.read(sys_config |> List.to_string) 
+      true ->
+        {:ok, [conf]} = Conform.SysConfig.read(sys_config |> List.to_string)
         final = Conform.Translate.to_config(schema, conf, config)
         Conform.SysConfig.write(sys_config, final) == :ok and sys_config
-      false -> 
-        {:ok, [conf]} = Conform.Config.read(sys_config |> List.to_string) 
+      false ->
+        {:ok, [conf]} = Conform.Config.read(sys_config |> List.to_string)
         translated = Conform.Translate.to_config(conf, config, schema)
         final = Conform.Config.merge(conf, translated)
         Conform.Config.write(sys_config, final) == :ok and sys_config

--- a/lib/exrm_reload/reload.ex
+++ b/lib/exrm_reload/reload.ex
@@ -15,16 +15,18 @@ defmodule ReleaseManager.Reload do
 
   @doc "Reload the configuration for list of application."
   def run(applications) do
-    {:ok, [[schema]]} = :init.get_argument(:conform_schema)
-    {:ok, [[config]]} = :init.get_argument(:conform_config)
-    {:ok, [[sys_config]]} = :init.get_argument(:config)
-    case :init.get_argument(:running_conf) do
-      {:ok, [[running_conf]]} -> File.copy! config, running_conf
-      _ -> :skip
-    end
-    generate_sys_config(schema, config, sys_config)
-    |> check_config!
-    |> reload(applications)
+    if Application.get_env(:exrm_reload, :dev) do
+      Mix.Config.read!("config/config.exs")
+    else
+      {:ok, [[schema]]} = :init.get_argument(:conform_schema)
+      {:ok, [[config]]} = :init.get_argument(:conform_config)
+      {:ok, [[sys_config]]} = :init.get_argument(:config)
+      case :init.get_argument(:running_conf) do
+        {:ok, [[running_conf]]} -> File.copy! config, running_conf
+        _ -> :skip
+      end
+      generate_sys_config(schema, config, sys_config) |> check_config!
+    end |> reload(applications)
   end
 
   defp generate_sys_config(schema, config, sys_config) do
@@ -66,14 +68,19 @@ defmodule ReleaseManager.Reload do
     {:ok, loaded_app_apec} = :application.get_all_key(application)
     case :code.where_is_file(Atom.to_char_list(application) ++ '.app') do
       :non_existing -> loaded_app_apec
-      app_spec_path when is_list(app_spec_path) -> parse_app_file(app_spec_path)
+      app_spec_path when is_list(app_spec_path) -> parse_app_file(application, app_spec_path)
     end
   end
 
-  defp parse_app_file(app_spec_path) do
+  defp parse_app_file(application, app_spec_path) do
     case :file.consult(app_spec_path) do
-      {:ok, [{:application, _, spec}]} -> spec
-      {:error, _Reason} -> :incorrect_spec
+      {:ok, [{:application, _, spec}]} ->
+        spec
+      {:error, :enotdir} ->
+        {:ok, spec} = :application.get_all_key(application)
+        spec
+      {:error, _reason} ->
+        :incorrect_spec
     end
   end
 

--- a/lib/exrm_reload/watcher.ex
+++ b/lib/exrm_reload/watcher.ex
@@ -1,0 +1,22 @@
+defmodule ExrmReload.Watcher do
+  use GenServer
+  require Logger
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, [], [name: __MODULE__])
+  end
+
+  def init([]) do
+    :fs.subscribe(:exrm_reload_watcher)
+    {:ok, nil}
+  end
+
+  def handle_info({_, {:fs, :file_event}, {file, _}}, state) do
+    if Path.extname(file) == ".conf" do
+      Logger.info "configuration changes are detected, reloading"
+      ReleaseManager.Reload.run()
+    end
+    {:noreply, state}
+  end
+
+end

--- a/lib/exrm_reload/watcher.ex
+++ b/lib/exrm_reload/watcher.ex
@@ -12,7 +12,7 @@ defmodule ExrmReload.Watcher do
   end
 
   def handle_info({_, {:fs, :file_event}, {file, _}}, state) do
-    if Path.extname(file) == ".conf" do
+    if Path.extname(file) == ".conf" or Application.get_env(:exrm_reload, :dev) do
       Logger.info "configuration changes are detected, reloading"
       ReleaseManager.Reload.run()
     end

--- a/mix.exs
+++ b/mix.exs
@@ -11,10 +11,12 @@ defmodule ExrmReload.Mixfile do
   end
 
   def application do
-    [applications: [:conform]]
+    [applications: [:logger, :conform, :fs],
+     mod: {ExrmReload, []}]
   end
 
   defp deps do
-    [{:conform, github: "xerions/conform", branch: "master"}]
+    [{:conform, github: "xerions/conform", branch: "master"},
+     {:fs, github: "liveforeverx/fs", branch: "master"}]
   end
 end

--- a/test/test_application/mix.exs
+++ b/test/test_application/mix.exs
@@ -2,7 +2,7 @@ defmodule TestApplication.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :test_application, 
+    [app: :test_application,
      version: "0.0.1",
      deps: deps]
   end


### PR DESCRIPTION
Setting of `config.watch` will start an listener, which will subscribes to file changes on the directory, where config is placed, and reload configuration, if config is changed.
